### PR TITLE
Change production information

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you want to test out this sample, you will have to follow the next steps:
 
 - Run `gulp package-solution` or `gulp package-solution --ship` depending on if you want to use a debug or release build
 - To upload the solution package to your **test** environment, run: `gulp upload-app-pkg`
-- To upload the solution package to your **test** environment, run: `gulp upload-app-pkg --ship`
+- To upload the solution package to your **production** environment, run: `gulp upload-app-pkg --ship`
 - Check out the app catalog
 
 **Important**: when you add the solution package the first time to the app catalog, be sure to manually trigger the deploy. Afterwards you do not have to do this anymore, and you can just keep publishing new packages via your command prompt.


### PR DESCRIPTION
On readme at line 26 - To upload the solution package to your **test** environment, run: `gulp upload-app-pkg --ship` should be production I guess.